### PR TITLE
replace uses of happenings.utils.common.now with get_now()

### DIFF
--- a/happenings/templatetags/happenings_tags.py
+++ b/happenings/templatetags/happenings_tags.py
@@ -13,7 +13,7 @@ from happenings.utils.common import (
     get_net_category_tag,
     get_qs,
     clean_year_month,
-    now
+    get_now
 )
 
 register = Library()
@@ -22,6 +22,7 @@ start_day = getattr(settings, "CALENDAR_START_DAY", 0)
 
 @register.simple_tag
 def show_calendar(req, mini=False):
+    now = get_now()
     net, category, tag = get_net_category_tag(req)
     year = now.year
     month = now.month + net
@@ -44,7 +45,9 @@ def show_calendar(req, mini=False):
 
 
 @register.inclusion_tag('happenings/partials/upcoming_events.html')
-def upcoming_events(now=timezone.localtime(timezone.now()), finish=90, num=5):
+def upcoming_events(now=None, finish=90, num=5):
+    if now is None:
+        now = get_now()
     finish = now + timezone.timedelta(days=finish)
     finish = finish.replace(hour=23, minute=59, second=59, microsecond=999)
     all_upcoming = (UpcomingEvents(x, now, finish, num).get_upcoming_events()
@@ -58,7 +61,9 @@ def upcoming_events(now=timezone.localtime(timezone.now()), finish=90, num=5):
 
 
 @register.inclusion_tag('happenings/partials/happening_events.html')
-def current_happenings(now=timezone.localtime(timezone.now())):
+def current_happenings(now=None):
+    if now is None:
+        now = get_now()
     temp = now
     drepl = lambda x: temp.replace(  # replace hr, min, sec, msec of 'now'
         hour=x.l_start_date.hour,

--- a/happenings/utils/common.py
+++ b/happenings/utils/common.py
@@ -10,9 +10,9 @@ from django.utils.six.moves import xrange
 get_now = lambda: timezone.localtime(timezone.now())
 
 now = get_now()
-# what will happen for long running processes in mudules that use ``from happenings.utils.common import now``?
-# Will it be set on initialization of modules or will it be always new?
-# Maybe we should always use get_now() instead of now to make things clear?
+# Warning! please do not use 'now' anywhere: it is initialized on first import
+# and so it will not change for days in some environments. It's here just for backward
+# compatibility
 
 
 def inc_month(month, year):

--- a/happenings/views.py
+++ b/happenings/views.py
@@ -57,8 +57,9 @@ class EventMonthView(GenericEventView):
         querystrings. If none, or if cal_ignore qs is specified,
         sets year and month to this year and this month.
         """
-        year = c.now.year
-        month = c.now.month + net
+        now = c.get_now()
+        year = now.year
+        month = now.month + net
         month_orig = None
 
         if 'cal_ignore=true' not in qs:
@@ -203,14 +204,16 @@ class EventDetailView(DetailView):
         )
 
     def get_cncl_days(self):
+        now = c.get_now()
         cncl = self.object.cancellations.all()
-        return [(x.date, x.reason) for x in cncl if x.date >= c.now.date()]
+        return [(x.date, x.reason) for x in cncl if x.date >= now.date()]
 
     def check_cncl(self, d):
         cncl = self.object.cancellations.all()
         return True if [x for x in cncl if x.date == d] else False
 
     def get_context_data(self, **kwargs):
+        now = c.get_now()
         context = super(EventDetailView, self).get_context_data(**kwargs)
         e = self.object
 
@@ -222,8 +225,8 @@ class EventDetailView(DetailView):
 
         event = [e]  # event needs to be an iterable, see get_next_event()
         if not e.repeats('NEVER'):  # event is ongoing; get next occurrence
-            if e.will_occur(c.now):
-                year, month, day = get_next_event(event, c.now)
+            if e.will_occur(now):
+                year, month, day = get_next_event(event, now)
                 next_event = date(year, month, day)
                 context['next_event'] = date(year, month, day)
                 context['next_or_prev_cncl'] = self.check_cncl(next_event)


### PR DESCRIPTION
Do not ever use datetime variables defined at module level -- this will cause headaches.

This also should fix #9