### PR TITLE
Richer context for rendering

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -143,6 +143,14 @@ your own style. Note also that, because the request object needs to be
 included in the tag, you must include "django.core.context_processors.request"
 in TEMPLATE_CONTEXT_PROCESSORS in your settings.py.
 
+If you are using custom templates for calendar and want to access all variables
+from current template context then you can call ``show_calendar`` tag with
+``inherit_context=True`` argument:
+
+    <div id="event-calendar">
+        {% show_calendar request inherit_context=True %}
+    </div>
+
 Include ``upcoming_events`` in your template like this::
 
     {% upcoming_events %}

--- a/happenings/templates/happenings/partials/calendar/mini_popover.html
+++ b/happenings/templates/happenings/partials/calendar/mini_popover.html
@@ -2,9 +2,9 @@
   {% for event in events %}
     <li><a href="{{ event.get_absolute_url }}">
       {% if event.l_start_date.minute %}
-        {{ l_start_date|time:CALENDAR_TIME_FORMAT }}
+        {{ event.l_start_date|time:CALENDAR_TIME_FORMAT }}
       {% else %}
-        {{ l_start_date|time:CALENDAR_HOUR_FORMAT }}
+        {{ event.l_start_date|time:CALENDAR_HOUR_FORMAT }}
       {% endif %}
       {{ event.title }}{{ event.title_extra }}
     </a></li>

--- a/happenings/templatetags/happenings_tags.py
+++ b/happenings/templatetags/happenings_tags.py
@@ -20,8 +20,8 @@ register = Library()
 start_day = getattr(settings, "CALENDAR_START_DAY", 0)
 
 
-@register.simple_tag
-def show_calendar(req, mini=False):
+@register.simple_tag(takes_context=True)
+def show_calendar(context, req, mini=False, inherit_context=False):
     now = get_now()
     net, category, tag = get_net_category_tag(req)
     year = now.year
@@ -39,8 +39,10 @@ def show_calendar(req, mini=False):
     qs = req.META['QUERY_STRING']
     if qs:  # get any querystrings that are not next/prev
         qs = get_qs(qs)
+    if not inherit_context:
+        context = {}
     return month_display(
-        year, month, all_month_events, start_day, net, qs, mini=mini
+        year, month, all_month_events, start_day, net, qs, mini=mini, request=req, context=context,
     )
 
 

--- a/happenings/templatetags/happenings_tags.py
+++ b/happenings/templatetags/happenings_tags.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals
 
 import heapq
 
-from django.template import Library
+from django.template import Library, TemplateSyntaxError
 from django.conf import settings
 from django.utils import timezone
 
@@ -21,7 +21,10 @@ start_day = getattr(settings, "CALENDAR_START_DAY", 0)
 
 
 @register.simple_tag(takes_context=True)
-def show_calendar(context, req, mini=False, inherit_context=False):
+def show_calendar(context, req=None, mini=False, inherit_context=False):
+    req = req or context.get('request', None)
+    if not (req and hasattr(req, 'path') and hasattr(req, 'META')):
+        raise TemplateSyntaxError(r"{% show_calendar %} should be called with HttpRequest instance as first argument or it should be available as `request` variable in template context")
     now = get_now()
     net, category, tag = get_net_category_tag(req)
     year = now.year

--- a/happenings/utils/calendars.py
+++ b/happenings/utils/calendars.py
@@ -46,12 +46,14 @@ if not CALENDAR_HOUR_FORMAT:
 
 
 class GenericCalendar(HTMLCalendar):
-    def __init__(self, year, month, count, all_month_events, *args):
-        super(GenericCalendar, self).__init__(*args)
+    def __init__(self, year, month, count, all_month_events, firstweekday=0, request=None, base_context=None, *args, **kwargs):
+        super(GenericCalendar, self).__init__(firstweekday)
         self.yr = year
         self.mo = month
         self.count = count  # defaultdict in {date:[(title1, pk1), (title2, pk2),]} format
         self.events = all_month_events
+        self.request = request
+        self.base_context = base_context or {}
         self._context = None
 
 #    def add_occurrence(self):
@@ -64,14 +66,16 @@ class GenericCalendar(HTMLCalendar):
     def get_context(self, day=None):
         if self._context is None:
             now = get_now()
-            context = {
+            context = dict(self.base_context)
+            context.update({
                 'URLS_NAMESPACE': URLS_NAMESPACE,
                 'CALENDAR_TIME_FORMAT': CALENDAR_TIME_FORMAT,
                 'CALENDAR_HOUR_FORMAT': CALENDAR_HOUR_FORMAT,
                 'calendar': self,
                 'is_current_day': False,
                 'now': now,
-            }
+                'request': self.request,
+            })
             self._context = context
         return dict(self._context)
 

--- a/happenings/utils/calendars.py
+++ b/happenings/utils/calendars.py
@@ -169,8 +169,8 @@ class EventCalendar(GenericCalendar):
 
 
 class MiniEventCalendar(EventCalendar):
-    def __init__(self, *args):
-        super(MiniEventCalendar, self).__init__(*args)
+    def __init__(self, *args, **kwargs):
+        super(MiniEventCalendar, self).__init__(*args, **kwargs)
         # Change count from a defaultdict to a regular dict, so that when we
         # try and check if there are days in count, they won't be added if they
         # aren't there.

--- a/happenings/utils/displays.py
+++ b/happenings/utils/displays.py
@@ -41,7 +41,7 @@ def add_occurrences(events, count):
 
 
 def month_display(year, month, all_month_events,
-                  start_day, net, qs, mini=False):
+                  start_day, net, qs, mini=False, request=None, context=None):
     """
     A function that returns an html calendar for the given
     month in the given year, with the number of events for that month
@@ -60,9 +60,9 @@ def month_display(year, month, all_month_events,
 
     args = (year, month, count, all_month_events, start_day)
     if not mini:
-        html_cal = EventCalendar(*args).formatmonth(year, month, net=net, qs=qs)
+        html_cal = EventCalendar(request=request, context=context, *args).formatmonth(year, month, net=net, qs=qs)
     else:
-        html_cal = MiniEventCalendar(*args).formatmonth(year, month, net=net, qs=qs)
+        html_cal = MiniEventCalendar(request=request, context=context, *args).formatmonth(year, month, net=net, qs=qs)
 
     nxt, prev = get_next_and_prev(net)
     extra_qs = ('&' + '&'.join(qs)) if qs else ''

--- a/happenings/views.py
+++ b/happenings/views.py
@@ -126,7 +126,8 @@ class EventMonthView(GenericEventView):
 
         start_day = getattr(settings, "CALENDAR_START_DAY", 0)
         context['calendar'] = month_display(
-            year, month, all_month_events, start_day, self.net, qs, mini
+            year, month, all_month_events, start_day, self.net, qs, mini,
+            request=self.request,
         )
 
         context['show_events'] = False

--- a/tests/unit_tests/test_template_tags/test_show_calendar.py
+++ b/tests/unit_tests/test_template_tags/test_show_calendar.py
@@ -19,7 +19,7 @@ class ShowCalendarTemplateTagTest(TestCase):
 
     def test_show_calendar_no_events(self):
         req = self.factory.get(self.url)
-        cal = show_calendar(req)
+        cal = show_calendar({}, req)
         self.assertIn(str(now.month), cal)
         self.assertIn(str(now.year), cal)
         self.assertNotIn('calendar-event', cal)
@@ -50,7 +50,7 @@ class ShowCalendarTemplateTagTest(TestCase):
         event2.save()
 
         req = self.factory.get(self.url, {'cal_category': 'birthday'})
-        cal = show_calendar(req, mini=True)
+        cal = show_calendar({}, req, mini=True)
         self.assertIn(str(now.month), cal)
         self.assertIn(str(now.year), cal)
         self.assertNotIn(event.title, cal)

--- a/tox.ini
+++ b/tox.ini
@@ -73,6 +73,7 @@ deps = {[base3]deps}
 
 
 [testenv:coverage]
+passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 commands = coverage run \
     --branch \
     --omit='*.tox*','tests/manage.py','tests/urls.py','tests/settings.py','*migrations*' \


### PR DESCRIPTION
This will allow to use "request" in calendar templates. ``show_calendar `` tag now also accepts ``inherit_context`` argument: when set to True it will pass current context to calendar renderer.

Maybe ``inherit_context`` should be set to ``True`` by default. But this also will require changes to ``EventMonthView``: to make things consistent it should contain all variables of all context_processors when rendering calendar just like ``show_calendar`` with new default value for ``inherit_context``. Maybe EventMonthView should directly use ``show_template`` instead of ``month_display``?