### PR TITLE
Removes future template tag load

### DIFF
--- a/happenings/templates/happenings/partials/calendar/day_cell.html
+++ b/happenings/templates/happenings/partials/calendar/day_cell.html
@@ -1,5 +1,4 @@
 {% load i18n %}
-{% load url from future %}
 <td class="{{ cssclass }} {% if is_current_day %}calendar-today{% endif %}">
 <div class="td-inner">
   <a


### PR DESCRIPTION
Removes "load url from future" as it is now loaded by default

I think it was removed in [django 1.5](http://django.readthedocs.org/en/latest/releases/1.5.html) and now it is throwing an error in django 1.9