### PR TITLE
Update to Django 2.0

### DIFF
--- a/happenings/models.py
+++ b/happenings/models.py
@@ -4,7 +4,7 @@ import datetime
 
 from django.conf import settings
 from django.core.exceptions import ValidationError
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.db import models
 from django.template.loader import render_to_string
 from django.utils import timezone


### PR DESCRIPTION
Django 2.0 removes the django.core.urlresolvers module, which was moved to django.urls in version 1.10. 